### PR TITLE
Add support for AppendLimit and ReportUpdates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+.obj/
 xyz.openbmc_project.Telemetry.service
 telemetry
 __pycache__

--- a/src/interfaces/metric.hpp
+++ b/src/interfaces/metric.hpp
@@ -18,6 +18,7 @@ class Metric
     virtual void initialize() = 0;
     virtual std::vector<MetricValue> getReadings() const = 0;
     virtual LabeledMetricParameters dumpConfiguration() const = 0;
+    virtual uint64_t sensorCount() const = 0;
 };
 
 } // namespace interfaces

--- a/src/interfaces/report_factory.hpp
+++ b/src/interfaces/report_factory.hpp
@@ -26,7 +26,8 @@ class ReportFactory
     virtual std::unique_ptr<interfaces::Report> make(
         const std::string& name, const std::string& reportingType,
         bool emitsReadingsSignal, bool logToMetricReportsCollection,
-        Milliseconds period, ReportManager& reportManager,
+        Milliseconds period, uint64_t appendLimit,
+        const std::string& reportUpdates, ReportManager& reportManager,
         JsonStorage& reportStorage,
         std::vector<LabeledMetricParameters> labeledMetricParams) const = 0;
 };

--- a/src/metric.cpp
+++ b/src/metric.cpp
@@ -227,6 +227,11 @@ std::vector<std::unique_ptr<Metric::CollectionData>>
     return result;
 }
 
+uint64_t Metric::sensorCount() const
+{
+    return sensors.size();
+}
+
 void Metric::attemptUnpackJsonMetadata()
 {
     using MetricMetadata =

--- a/src/metric.hpp
+++ b/src/metric.hpp
@@ -21,6 +21,7 @@ class Metric :
     void sensorUpdated(interfaces::Sensor&, uint64_t) override;
     void sensorUpdated(interfaces::Sensor&, uint64_t, double value) override;
     LabeledMetricParameters dumpConfiguration() const override;
+    uint64_t sensorCount() const override;
 
   private:
     class CollectionData;

--- a/src/report.cpp
+++ b/src/report.cpp
@@ -11,10 +11,11 @@
 Report::Report(boost::asio::io_context& ioc,
                const std::shared_ptr<sdbusplus::asio::object_server>& objServer,
                const std::string& reportName,
-               const std::string& reportingTypeIn,
+               const ReportingType reportingTypeIn,
                const bool emitsReadingsUpdateIn,
                const bool logToMetricReportsCollectionIn,
-               const Milliseconds intervalIn,
+               const Milliseconds intervalIn, uint64_t appendLimitIn,
+               const ReportUpdates reportUpdatesIn,
                interfaces::ReportManager& reportManager,
                interfaces::JsonStorage& reportStorageIn,
                std::vector<std::shared_ptr<interfaces::Metric>> metricsIn) :
@@ -22,6 +23,10 @@ Report::Report(boost::asio::io_context& ioc,
     path(reportDir + name), reportingType(reportingTypeIn),
     interval(intervalIn), emitsReadingsUpdate(emitsReadingsUpdateIn),
     logToMetricReportsCollection(logToMetricReportsCollectionIn),
+    appendLimit(deduceAppendLimit(appendLimitIn, reportUpdatesIn,
+                                  reportingTypeIn, metricsIn)),
+    readingsBuffer(appendLimit),
+    reportUpdates(deduceReportUpdates(reportUpdatesIn, reportingTypeIn)),
     objServer(objServer), metrics(std::move(metricsIn)), timer(ioc),
     fileName(std::to_string(std::hash<std::string>{}(name))),
     reportStorage(reportStorageIn)
@@ -54,7 +59,7 @@ Report::Report(boost::asio::io_context& ioc,
     persistency = storeConfiguration();
     reportIface = makeReportInterface();
 
-    if (reportingType == "Periodic")
+    if (reportingType == ReportingType::Periodic)
     {
         scheduleTimer(interval);
     }
@@ -62,6 +67,42 @@ Report::Report(boost::asio::io_context& ioc,
     for (auto& metric : this->metrics)
     {
         metric->initialize();
+    }
+}
+
+ReportUpdates
+    Report::deduceReportUpdates(const ReportUpdates reportUpdatesIn,
+                                const ReportingType reportingTypeIn) const
+{
+    if (reportUpdatesIn == ReportUpdates::Default ||
+        reportingTypeIn == ReportingType::OnRequest)
+    {
+        return ReportUpdates::Overwrite;
+    }
+    else
+    {
+        return reportUpdatesIn;
+    }
+}
+
+uint64_t Report::deduceAppendLimit(
+    const uint64_t appendLimitIn, const ReportUpdates reportUpdatesIn,
+    const ReportingType reportingTypeIn,
+    const std::vector<std::shared_ptr<interfaces::Metric>>& metricsIn) const
+{
+    if (reportUpdatesIn != ReportUpdates::Default &&
+        reportingTypeIn != ReportingType::OnRequest)
+    {
+        return appendLimitIn;
+    }
+    else
+    {
+        uint64_t appendLimit = 0;
+        for (auto& metric : metricsIn)
+        {
+            appendLimit += metric->sensorCount();
+        }
+        return appendLimit;
     }
 }
 
@@ -109,8 +150,8 @@ std::unique_ptr<sdbusplus::asio::dbus_interface> Report::makeReportInterface()
     dbusIface->register_property_r("Readings", readings, readingsFlag,
                                    [this](const auto&) { return readings; });
     dbusIface->register_property_r(
-        "ReportingType", reportingType, sdbusplus::vtable::property_::const_,
-        [this](const auto&) { return reportingType; });
+        "ReportingType", std::string(), sdbusplus::vtable::property_::const_,
+        [this](const auto&) { return reportingTypeToString(reportingType); });
     dbusIface->register_property_r(
         "ReadingParameters", readingParametersPastVersion,
         sdbusplus::vtable::property_::const_,
@@ -127,8 +168,28 @@ std::unique_ptr<sdbusplus::asio::dbus_interface> Report::makeReportInterface()
         "LogToMetricReportsCollection", logToMetricReportsCollection,
         sdbusplus::vtable::property_::const_,
         [this](const auto&) { return logToMetricReportsCollection; });
+    dbusIface->register_property_r("AppendLimit", appendLimit,
+                                   sdbusplus::vtable::property_::emits_change,
+                                   [this](const auto&) { return appendLimit; });
+    dbusIface->register_property_rw(
+        "ReportUpdates", std::string(),
+        sdbusplus::vtable::property_::emits_change,
+        [this](std::string newVal, const auto&) {
+            ReportManager::verifyReportUpdates(newVal);
+            if (reportingType != ReportingType::OnRequest)
+            {
+                if (auto newValConverted = stringToReportUpdates(newVal);
+                    newValConverted != ReportUpdates::Default)
+                {
+                    reportUpdates = newValConverted;
+                    return true;
+                }
+            }
+            return false;
+        },
+        [this](const auto&) { return reportUpdatesToString(reportUpdates); });
     dbusIface->register_method("Update", [this] {
-        if (reportingType == "OnRequest")
+        if (reportingType == ReportingType::OnRequest)
         {
             updateReadings();
         }
@@ -158,23 +219,33 @@ void Report::scheduleTimer(Milliseconds timerInterval)
 
 void Report::updateReadings()
 {
-    using ReadingsValue = std::tuple_element_t<1, Readings>;
-    std::get<ReadingsValue>(cachedReadings).clear();
+    if (reportUpdates == ReportUpdates::Overwrite)
+    {
+        readingsBuffer.clear();
+    }
+    else if (reportUpdates == ReportUpdates::AppendStopWhenFull &&
+             readingsBuffer.isFull())
+    {
+        return;
+    }
 
     for (const auto& metric : metrics)
     {
         for (const auto& reading : metric->getReadings())
         {
-            std::get<1>(cachedReadings)
-                .emplace_back(reading.id, reading.metadata, reading.value,
-                              reading.timestamp);
+            if ((reportUpdates == ReportUpdates::AppendStopWhenFull ||
+                 reportUpdates == ReportUpdates::Overwrite) &&
+                readingsBuffer.isFull())
+            {
+                break;
+            }
+            readingsBuffer.emplace(reading.id, reading.metadata, reading.value,
+                                   reading.timestamp);
         }
     }
 
-    using ReadingsTimestamp = std::tuple_element_t<0, Readings>;
-    std::get<ReadingsTimestamp>(cachedReadings) = std::time(0);
-
-    std::swap(readings, cachedReadings);
+    readings = {std::time(0), std::vector<ReadingData>(readingsBuffer.begin(),
+                                                       readingsBuffer.end())};
 
     reportIface->signal_property("Readings");
 }
@@ -187,10 +258,12 @@ bool Report::storeConfiguration() const
 
         data["Version"] = reportVersion;
         data["Name"] = name;
-        data["ReportingType"] = reportingType;
+        data["ReportingType"] = reportingTypeToString(reportingType);
         data["EmitsReadingsUpdate"] = emitsReadingsUpdate;
         data["LogToMetricReportsCollection"] = logToMetricReportsCollection;
         data["Interval"] = interval.count();
+        data["AppendLimit"] = appendLimit;
+        data["ReportUpdates"] = reportUpdatesToString(reportUpdates);
         data["ReadingParameters"] =
             utils::transform(metrics, [](const auto& metric) {
                 return metric->dumpConfiguration();

--- a/src/report_factory.cpp
+++ b/src/report_factory.cpp
@@ -17,9 +17,11 @@ ReportFactory::ReportFactory(
 {}
 
 std::unique_ptr<interfaces::Report> ReportFactory::make(
-    const std::string& name, const std::string& reportingType,
+    const std::string& name, const std::string& reportingTypeStr,
     bool emitsReadingsSignal, bool logToMetricReportsCollection,
-    Milliseconds period, interfaces::ReportManager& reportManager,
+    Milliseconds period, uint64_t appendLimit,
+    const std::string& reportUpdatesStr,
+    interfaces::ReportManager& reportManager,
     interfaces::JsonStorage& reportStorage,
     std::vector<LabeledMetricParameters> labeledMetricParams) const
 {
@@ -38,10 +40,13 @@ std::unique_ptr<interfaces::Report> ReportFactory::make(
                 std::make_unique<Clock>());
         });
 
+    auto reportingType = stringToReportingType(reportingTypeStr);
+    auto reportUpdates = stringToReportUpdates(reportUpdatesStr);
+
     return std::make_unique<Report>(
         bus->get_io_context(), objServer, name, reportingType,
-        emitsReadingsSignal, logToMetricReportsCollection, period,
-        reportManager, reportStorage, std::move(metrics));
+        emitsReadingsSignal, logToMetricReportsCollection, period, appendLimit,
+        reportUpdates, reportManager, reportStorage, std::move(metrics));
 }
 
 Sensors ReportFactory::getSensors(

--- a/src/report_factory.hpp
+++ b/src/report_factory.hpp
@@ -22,7 +22,9 @@ class ReportFactory : public interfaces::ReportFactory
     std::unique_ptr<interfaces::Report>
         make(const std::string& name, const std::string& reportingType,
              bool emitsReadingsSignal, bool logToMetricReportsCollection,
-             Milliseconds period, interfaces::ReportManager& reportManager,
+             Milliseconds period, uint64_t appendLimitIn,
+             const std::string& reportUpdatesIn,
+             interfaces::ReportManager& reportManager,
              interfaces::JsonStorage& reportStorage,
              std::vector<LabeledMetricParameters> labeledMetricParams)
             const override;

--- a/src/report_manager.hpp
+++ b/src/report_manager.hpp
@@ -41,19 +41,21 @@ class ReportManager : public interfaces::ReportManager
     void verifyReportNameLength(const std::string& reportName);
     void verifyAddReport(
         const std::string& reportName, const std::string& reportingType,
-        Milliseconds interval,
+        Milliseconds interval, const std::string& reportUpdates,
         const std::vector<LabeledMetricParameters>& readingParams);
     interfaces::Report& addReport(boost::asio::yield_context& yield,
                                   const std::string& reportName,
                                   const std::string& reportingType,
                                   const bool emitsReadingsUpdate,
                                   const bool logToMetricReportsCollection,
-                                  Milliseconds interval,
+                                  Milliseconds interval, uint64_t appendLimit,
+                                  const std::string& reportUpdates,
                                   ReadingParameters metricParams);
     interfaces::Report& addReport(
         const std::string& reportName, const std::string& reportingType,
         const bool emitsReadingsUpdate, const bool logToMetricReportsCollection,
-        Milliseconds interval,
+        Milliseconds interval, uint64_t appendLimit,
+        const std::string& reportUpdates,
         std::vector<LabeledMetricParameters> metricParams);
     void loadFromPersistent();
 
@@ -69,4 +71,8 @@ class ReportManager : public interfaces::ReportManager
         "/xyz/openbmc_project/Telemetry/Reports";
     static constexpr std::array<std::string_view, 2> supportedReportingType = {
         "Periodic", "OnRequest"};
+    static constexpr std::array<std::string_view, 4> supportedReportUpdates = {
+        "Overwrite", "AppendStopWhenFull", "AppendWrapWhenFull", "Default"};
+
+    static void verifyReportUpdates(const std::string& reportUpdates);
 };

--- a/src/sensor_cache.hpp
+++ b/src/sensor_cache.hpp
@@ -5,7 +5,6 @@
 #include <boost/container/flat_map.hpp>
 #include <boost/system/error_code.hpp>
 
-#include <iostream>
 #include <memory>
 #include <string_view>
 

--- a/src/types/report_types.hpp
+++ b/src/types/report_types.hpp
@@ -33,9 +33,67 @@ using LabeledMetricParameters = utils::LabeledTuple<
     utils::tstring::Id, utils::tstring::MetricMetadata,
     utils::tstring::CollectionTimeScope, utils::tstring::CollectionDuration>;
 
-using Readings = std::tuple<
-    uint64_t,
-    std::vector<std::tuple<std::string, std::string, double, uint64_t>>>;
+using ReadingData = std::tuple<std::string, std::string, double, uint64_t>;
+
+using Readings = std::tuple<uint64_t, std::vector<ReadingData>>;
 
 ReadingParameters
     toReadingParameters(const std::vector<LabeledMetricParameters>& labeled);
+
+enum class ReportUpdates
+{
+    Overwrite = 0,
+    AppendStopWhenFull,
+    AppendWrapWhenFull,
+    NewReport,
+    Default
+};
+
+namespace details
+{
+constexpr std::array<std::pair<std::string_view, ReportUpdates>, 5>
+    convDataReportUpdates = {
+        std::make_pair("Overwrite", ReportUpdates::Overwrite),
+        std::make_pair("AppendStopWhenFull", ReportUpdates::AppendStopWhenFull),
+        std::make_pair("AppendWrapWhenFull", ReportUpdates::AppendWrapWhenFull),
+        std::make_pair("NewReport", ReportUpdates::NewReport),
+        std::make_pair("Default", ReportUpdates::Default)};
+
+} // namespace details
+
+inline ReportUpdates stringToReportUpdates(const std::string& str)
+{
+    return utils::stringToEnum(details::convDataReportUpdates, str);
+}
+
+inline std::string reportUpdatesToString(ReportUpdates v)
+{
+    return std::string(utils::enumToString(details::convDataReportUpdates, v));
+}
+
+enum class ReportingType
+{
+    OnChange = 0,
+    OnRequest,
+    Periodic
+};
+
+namespace details
+{
+constexpr std::array<std::pair<std::string_view, ReportingType>, 3>
+    convDataReportingType = {
+        std::make_pair("OnChange", ReportingType::OnChange),
+        std::make_pair("OnRequest", ReportingType::OnRequest),
+        std::make_pair("Periodic", ReportingType::Periodic)};
+
+} // namespace details
+
+inline ReportingType stringToReportingType(const std::string& str)
+{
+    return utils::stringToEnum(details::convDataReportingType, str);
+}
+
+inline std::string reportingTypeToString(ReportingType v)
+{
+    return std::string(utils::enumToString(details::convDataReportingType, v));
+}

--- a/src/utils/circular_vector.hpp
+++ b/src/utils/circular_vector.hpp
@@ -1,0 +1,61 @@
+#include <vector>
+
+template <class T>
+class CircularVector
+{
+  public:
+    CircularVector(size_t maxSizeIn, bool reserveIn = false) :
+        maxSize(maxSizeIn), reserve(reserveIn)
+    {
+        clear();
+    }
+
+    template <class... Args>
+    void emplace(Args&&... args)
+    {
+        if (maxSize == 0)
+        {
+            return;
+        }
+        if (vec.size() == maxSize)
+        {
+            vec.at(idx) = std::move(T(args...));
+        }
+        else
+        {
+            vec.emplace_back(args...);
+        }
+        idx = (idx + 1 == maxSize ? 0 : idx + 1);
+    }
+
+    void clear()
+    {
+        vec.clear();
+        idx = 0;
+        if (reserve)
+        {
+            vec.reserve(maxSize);
+        }
+    }
+
+    bool isFull() const
+    {
+        return vec.size() == maxSize;
+    }
+
+    typename std::vector<T>::const_iterator begin() const
+    {
+        return vec.begin();
+    }
+
+    typename std::vector<T>::const_iterator end() const
+    {
+        return vec.end();
+    }
+
+  private:
+    size_t maxSize;
+    size_t idx = 0;
+    bool reserve;
+    std::vector<T> vec;
+};

--- a/src/utils/conversion.hpp
+++ b/src/utils/conversion.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <boost/type_index.hpp>
+
 #include <algorithm>
 #include <array>
 #include <stdexcept>
@@ -14,7 +16,9 @@ inline T toEnum(std::underlying_type_t<T> x)
     if (x < static_cast<std::underlying_type_t<T>>(first) ||
         x > static_cast<std::underlying_type_t<T>>(last))
     {
-        throw std::out_of_range("Value is not in range of enum");
+        throw std::out_of_range("Value \"" + std::to_string(x) +
+                                "\" is not in range of " +
+                                boost::typeindex::type_id<T>().pretty_name());
     }
     return static_cast<T>(x);
 }
@@ -34,7 +38,9 @@ inline T stringToEnum(const std::array<std::pair<std::string_view, T>, N>& data,
         [&value](const auto& item) { return item.first == value; });
     if (it == std::end(data))
     {
-        throw std::out_of_range("Value is not in range of enum");
+        throw std::out_of_range("Value \"" + std::string(value) +
+                                "\" is not in range of " +
+                                boost::typeindex::type_id<T>().pretty_name());
     }
     return it->second;
 }
@@ -49,7 +55,10 @@ inline std::string_view
         [value](const auto& item) { return item.second == value; });
     if (it == std::end(data))
     {
-        throw std::out_of_range("Value is not in range of enum");
+        throw std::out_of_range("Value \"" +
+                                std::to_string(toUnderlying(value)) +
+                                "\" is not in range of " +
+                                boost::typeindex::type_id<T>().pretty_name());
     }
     return it->first;
 }

--- a/tests/src/mocks/metric_mock.hpp
+++ b/tests/src/mocks/metric_mock.hpp
@@ -19,4 +19,9 @@ class MetricMock : public interfaces::Metric
     MOCK_METHOD(std::vector<MetricValue>, getReadings, (), (const, override));
     MOCK_METHOD(LabeledMetricParameters, dumpConfiguration, (),
                 (const, override));
+
+    uint64_t sensorCount() const override
+    {
+        return getReadings().size();
+    }
 };

--- a/tests/src/mocks/report_factory_mock.hpp
+++ b/tests/src/mocks/report_factory_mock.hpp
@@ -35,7 +35,7 @@ class ReportFactoryMock : public interfaces::ReportFactory
             .WillByDefault(
                 WithArgs<1>(Invoke(&ReportFactoryMock::convertToLabeled)));
 
-        ON_CALL(*this, make(A<const std::string&>(), _, _, _, _, _, _, _))
+        ON_CALL(*this, make(A<const std::string&>(), _, _, _, _, _, _, _, _, _))
             .WillByDefault(WithArgs<0>(Invoke([](const std::string& name) {
                 return std::make_unique<NiceMock<ReportMock>>(name);
             })));
@@ -47,8 +47,8 @@ class ReportFactoryMock : public interfaces::ReportFactory
 
     MOCK_METHOD(std::unique_ptr<interfaces::Report>, make,
                 (const std::string&, const std::string&, bool, bool,
-                 Milliseconds, interfaces::ReportManager&,
-                 interfaces::JsonStorage&,
+                 Milliseconds, uint64_t, const std::string&,
+                 interfaces::ReportManager&, interfaces::JsonStorage&,
                  std::vector<LabeledMetricParameters>),
                 (const, override));
 
@@ -64,13 +64,14 @@ class ReportFactoryMock : public interfaces::ReportFactory
                                make(params.reportName(), params.reportingType(),
                                     params.emitReadingUpdate(),
                                     params.logToMetricReportCollection(),
-                                    params.interval(), rm, js,
+                                    params.interval(), params.appendLimit(),
+                                    params.reportUpdates(), rm, js,
                                     params.metricParameters()));
         }
         else
         {
             using testing::_;
-            return EXPECT_CALL(*this, make(_, _, _, _, _, rm, js, _));
+            return EXPECT_CALL(*this, make(_, _, _, _, _, _, _, rm, js, _));
         }
     }
 };

--- a/tests/src/params/report_params.hpp
+++ b/tests/src/params/report_params.hpp
@@ -64,6 +64,28 @@ class ReportParams final
         return intervalProperty;
     }
 
+    ReportParams& appendLimit(uint64_t val)
+    {
+        appendLimitProperty = val;
+        return *this;
+    }
+
+    uint64_t appendLimit() const
+    {
+        return appendLimitProperty;
+    }
+
+    ReportParams& reportUpdates(std::string val)
+    {
+        reportUpdatesProperty = val;
+        return *this;
+    }
+
+    std::string reportUpdates() const
+    {
+        return reportUpdatesProperty;
+    }
+
     ReportParams& metricParameters(std::vector<LabeledMetricParameters> val)
     {
         metricParametersProperty = std::move(val);
@@ -81,6 +103,8 @@ class ReportParams final
     bool emitReadingUpdateProperty = true;
     bool logToMetricReportCollectionProperty = true;
     Milliseconds intervalProperty = ReportManager::minInterval;
+    uint64_t appendLimitProperty = 0;
+    std::string reportUpdatesProperty = "Default";
     std::vector<LabeledMetricParameters> metricParametersProperty{
         {LabeledMetricParameters{
              {LabeledSensorParameters{"Service",

--- a/tests/src/test_report_manager.cpp
+++ b/tests/src/test_report_manager.cpp
@@ -63,7 +63,8 @@ class TestReportManager : public Test
             ReportManager::reportManagerIfaceName, "AddReportFutureVersion",
             params.reportName(), params.reportingType(),
             params.emitReadingUpdate(), params.logToMetricReportCollection(),
-            params.interval().count(),
+            params.interval().count(), params.appendLimit(),
+            params.reportUpdates(),
             toReadingParameters(params.metricParameters()));
         return DbusEnvironment::waitForFuture(addReportPromise.get_future());
     }
@@ -359,6 +360,8 @@ class TestReportManagerStorage : public TestReportManager
         {"LogToMetricReportsCollection",
          reportParams.logToMetricReportCollection()},
         {"Interval", reportParams.interval().count()},
+        {"ReportUpdates", reportParams.reportUpdates()},
+        {"AppendLimit", reportParams.appendLimit()},
         {"ReadingParameters", reportParams.metricParameters()}};
 };
 


### PR DESCRIPTION
Added 2 new properties for Report interface: AppendLimit and
ReportUpdates. They were also added as arguments to the future version
of AddReport method of ReportManager.

ReportUpdates property defines the report update behavior:
- Overwrite: Each report update overrides previous "Reading" property.
  "AppendLimit" set by user is respected, and defines maximum size of
  "Readings" property.
- AppendWrapWhenFull: New readings are appended until limit specified by
  "AppendLimit" is reached. Then oldest readings are overwritten by new
  ones.
- AppendStopWhenFull: New readings are appended until limit specified by
  "AppendLimit" is reached. Then updates are stopped.
- Default: Same as "Overwrite", but "AppendLimit" is deduced by the
  service. This special case is used only during creation of report - it
  cannot be set on existing one.
- NewReport: not supported yet and will be implemented in the future.

Tested:
- Both new properties can be accessed from dbus.
- Both properties are reflected in Readings property.
- Old AddReport method is working as before the change.
- UTs are passing.

Signed-off-by: Szymon Dompke <szymon.dompke@intel.com>
Change-Id: I8a18f7e68215f0f6e5c403b533d2c4ff479df69e