### PR TITLE
Increase AppendLimit to 32768

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -9,5 +9,5 @@ option('max-triggers', type: 'integer', min: 1, value: 10,
        description: 'Max number of Triggers')
 option('max-dbus-path-length', type: 'integer', min: 1, value: 4095,
        description: 'Max length of dbus object path')
-option('max-append-limit', type: 'integer', min: 0, value: 256,
+option('max-append-limit', type: 'integer', min: 0, value: 32768,
        description: 'Max AppendLimit value')


### PR DESCRIPTION
Based on internal use cases, telemetry reports need a higher
append limit for metric readings. 32768 was determined as
1) a power of 2,
2) higher than HMC's current usage,
3) Ability to collect one hour of data for 250 sensors reading
once every 30 seconds.

Signed-off-by: Ali Ahmed <ama213000@gmail.com>