### PR TITLE
Increase max metric limit

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,7 +1,7 @@
 option('buildtest', type: 'boolean', value: true, description: 'Build tests')
 option('max-reports', type: 'integer', min: 1, value: 10,
        description: 'Max number of Reports')
-option('max-reading-parameters', type: 'integer', min: 1, value: 200,
+option('max-reading-parameters', type: 'integer', min: 1, value: 300,
        description: 'Max number of metric properties in single report')
 option('min-interval', type: 'integer', min: 1, value: 1000,
        description: 'Minimal value of interval in milliseconds')


### PR DESCRIPTION
Increase meson option for total maximum Metrics/MetricProperties
limit from 200 to 300. Meson option name is max-reading-parameters.

Testing:
Monitored CPU usage of bmcweb for both rainier and everest systems.
Bmcweb spike in usage for around 2 seconds with max MetricProperty MRD.
MRD was periodic on 15 interval with 300 MetricProperties averaged over
30 seconds on everest system with 360 sensors. Max bmcweb usage was 9%
for brief instant when MRD post call is made.

Signed-off-by: Ali Ahmed <ama213000@gmail.com>