### PR TITLE
1110: Decrease AppendLimit to 16384

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -38,7 +38,7 @@ option(
     'max-append-limit',
     type: 'integer',
     min: 0,
-    value: 256,
+    value: 16384,
     description: 'Max AppendLimit value',
 )
 option(

--- a/tests/src/test_report_manager.cpp
+++ b/tests/src/test_report_manager.cpp
@@ -147,7 +147,7 @@ TEST_F(TestReportManager, addReportWithOnlyDefaultParams)
     EXPECT_CALL(reportFactoryMock, convertMetricParams(_, _));
     EXPECT_CALL(reportFactoryMock,
                 make("Report"s, "Report"s, ReportingType::onRequest,
-                     std::vector<ReportAction>{}, Milliseconds{}, 256,
+                     std::vector<ReportAction>{}, Milliseconds{}, 16384,
                      ReportUpdates::overwrite, _, _,
                      std::vector<LabeledMetricParameters>{}, true, Readings{}))
         .WillOnce(Return(ByMove(std::move(reportMockPtr))));


### PR DESCRIPTION
#### Decrease AppendLimit to 16384
```
    Need to decrease AppendLimit due to OOM defect 671580
    It was agreed with the HMC team to reduce the limit
    from 32768 by half to 16384
```