### PR TITLE
1110: Increase AppendLimit to 32768 (#4)

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -38,7 +38,7 @@ option(
     'max-append-limit',
     type: 'integer',
     min: 0,
-    value: 256,
+    value: 16384,
     description: 'Max AppendLimit value',
 )
 option(

--- a/meson.options
+++ b/meson.options
@@ -38,8 +38,7 @@ option(
     'max-append-limit',
     type: 'integer',
     min: 0,
-    value: 512,
-#   value: 16384,
+    value: 16384,
     description: 'Max AppendLimit value',
 )
 option(

--- a/meson.options
+++ b/meson.options
@@ -38,7 +38,8 @@ option(
     'max-append-limit',
     type: 'integer',
     min: 0,
-    value: 16384,
+    value: 512,
+#   value: 16384,
     description: 'Max AppendLimit value',
 )
 option(

--- a/meson.options
+++ b/meson.options
@@ -9,7 +9,7 @@ option('max-triggers', type: 'integer', min: 0, value: 10,
        description: 'Max number of Triggers')
 option('max-dbus-path-length', type: 'integer', min: 256, value: 4095,
        description: 'Max length of dbus object path')
-option('max-append-limit', type: 'integer', min: 0, value: 256,
+option('max-append-limit', type: 'integer', min: 0, value: 32768,
        description: 'Max AppendLimit value')
 option('max-id-name-length', type: 'integer', min: 32, value: 256,
        description: 'Max length of any "id" or "name" type field.')

--- a/tests/src/test_report_manager.cpp
+++ b/tests/src/test_report_manager.cpp
@@ -147,7 +147,7 @@ TEST_F(TestReportManager, addReportWithOnlyDefaultParams)
     EXPECT_CALL(reportFactoryMock, convertMetricParams(_, _));
     EXPECT_CALL(reportFactoryMock,
                 make("Report"s, "Report"s, ReportingType::onRequest,
-                     std::vector<ReportAction>{}, Milliseconds{}, 256,
+                     std::vector<ReportAction>{}, Milliseconds{}, 16384,
                      ReportUpdates::overwrite, _, _,
                      std::vector<LabeledMetricParameters>{}, true, Readings{}))
         .WillOnce(Return(ByMove(std::move(reportMockPtr))));


### PR DESCRIPTION
#### Increase AppendLimit to 32768 (#4)
```
Based on internal use cases, telemetry reports need a higher
append limit for metric readings. 32768 was determined as
1) a power of 2,
2) higher than HMC's current usage,
3) Ability to collect one hour of data for 250 sensors reading
once every 30 seconds.

Testing:
Set AppendLimit up to 11000 with 150 sensors on 400+ sensor system.
Monitored 'top' CPU usage for telemetry binary and bmcweb binary
which never ran above 5%. AppendLimit generated new metric entries
for the report.
Retrieve report did seem to take a little longer as report grew but
not significantly.
Tested various other lower limits and sensors

Signed-off-by: Ali Ahmed <ama213000@gmail.com>
```