### PR TITLE
1110: Decrease AppendLimit to 2048

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -38,7 +38,7 @@ option(
     'max-append-limit',
     type: 'integer',
     min: 0,
-    value: 8192,
+    value: 2048,
     description: 'Max AppendLimit value',
 )
 option(

--- a/tests/src/test_report_manager.cpp
+++ b/tests/src/test_report_manager.cpp
@@ -147,7 +147,7 @@ TEST_F(TestReportManager, addReportWithOnlyDefaultParams)
     EXPECT_CALL(reportFactoryMock, convertMetricParams(_, _));
     EXPECT_CALL(reportFactoryMock,
                 make("Report"s, "Report"s, ReportingType::onRequest,
-                     std::vector<ReportAction>{}, Milliseconds{}, 8192,
+                     std::vector<ReportAction>{}, Milliseconds{}, 2048,
                      ReportUpdates::overwrite, _, _,
                      std::vector<LabeledMetricParameters>{}, true, Readings{}))
         .WillOnce(Return(ByMove(std::move(reportMockPtr))));


### PR DESCRIPTION
This gives us a calculated max of 90MB, given 3 reports. As seen in 688885, even 12,704 pushes our memory usage over 150 MB.