### PR TITLE
1110: Decrease AppendLimit to 1024

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -38,7 +38,7 @@ option(
     'max-append-limit',
     type: 'integer',
     min: 0,
-    value: 8192,
+    value: 1024,
     description: 'Max AppendLimit value',
 )
 option(

--- a/tests/src/test_report_manager.cpp
+++ b/tests/src/test_report_manager.cpp
@@ -147,7 +147,7 @@ TEST_F(TestReportManager, addReportWithOnlyDefaultParams)
     EXPECT_CALL(reportFactoryMock, convertMetricParams(_, _));
     EXPECT_CALL(reportFactoryMock,
                 make("Report"s, "Report"s, ReportingType::onRequest,
-                     std::vector<ReportAction>{}, Milliseconds{}, 8192,
+                     std::vector<ReportAction>{}, Milliseconds{}, 1024,
                      ReportUpdates::overwrite, _, _,
                      std::vector<LabeledMetricParameters>{}, true, Readings{}))
         .WillOnce(Return(ByMove(std::move(reportMockPtr))));


### PR DESCRIPTION
This gives us a calculated max of more like 45MB, given 3 reports. As seen in 688885, even 12,704 pushes our memory usage over 150 MB. This is more inline with no app should have more than 5% of memory.