### PR TITLE
1060: Improve memory usage of AVG, MIN, MAX readings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'Telemetry',
     'cpp',
-    meson_version: '>=0.57.0',
+    meson_version: '>=0.58.0',
     default_options: [
         'buildtype=debugoptimized',
         'cpp_std=c++20',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -9,7 +9,7 @@ option('max-triggers', type: 'integer', min: 0, value: 10,
        description: 'Max number of Triggers')
 option('max-dbus-path-length', type: 'integer', min: 256, value: 4095,
        description: 'Max length of dbus object path')
-option('max-append-limit', type: 'integer', min: 0, value: 32768,
+option('max-append-limit', type: 'integer', min: 0, value: 1024,
        description: 'Max AppendLimit value')
 option('max-id-name-length', type: 'integer', min: 32, value: 256,
        description: 'Max length of any "id" or "name" type field.')

--- a/src/metrics/collection_data.cpp
+++ b/src/metrics/collection_data.cpp
@@ -36,7 +36,7 @@ class DataInterval : public CollectionData
     DataInterval(std::shared_ptr<CollectionFunction> function,
                  CollectionDuration duration) :
         function(std::move(function)),
-        duration(duration)
+        duration(duration), intervalStart(Milliseconds{0})
     {
         if (duration.t.count() == 0)
         {
@@ -47,52 +47,37 @@ class DataInterval : public CollectionData
 
     std::optional<double> update(Milliseconds timestamp) override
     {
-        if (readings.empty())
+        if (stats.count == 0)
         {
             return std::nullopt;
         }
 
-        cleanup(timestamp);
-
-        return function->calculate(readings, timestamp);
+        return function->calculate(stats, timestamp);
     }
 
     double update(Milliseconds timestamp, double reading) override
     {
-        readings.emplace_back(timestamp, reading);
-
-        cleanup(timestamp);
-
-        return function->calculate(readings, timestamp);
-    }
-
-  private:
-    void cleanup(Milliseconds timestamp)
-    {
-        auto it = readings.begin();
-        for (auto kt = std::next(readings.rbegin()); kt != readings.rend();
-             ++kt)
+        if (stats.count == 0)
         {
-            const auto& [nextItemTimestamp, nextItemReading] = *std::prev(kt);
-            if (timestamp >= nextItemTimestamp &&
-                timestamp - nextItemTimestamp > duration.t)
-            {
-                it = kt.base();
-                break;
-            }
+            intervalStart = timestamp;
         }
-        readings.erase(readings.begin(), it);
 
-        if (timestamp > duration.t)
+        if (intervalStart.count() > 0 &&
+            timestamp >= intervalStart + duration.t)
         {
-            readings.front().first =
-                std::max(readings.front().first, timestamp - duration.t);
+            stats.reset();
+            intervalStart = timestamp;
         }
+
+        stats.addReading(timestamp, reading);
+
+        return function->calculate(stats, timestamp);
     }
 
     std::shared_ptr<CollectionFunction> function;
-    std::vector<ReadingItem> readings;
+    StreamingStats stats;
     CollectionDuration duration;
+    Milliseconds intervalStart;
 };
 
 class DataStartup : public CollectionData
@@ -104,23 +89,24 @@ class DataStartup : public CollectionData
 
     std::optional<double> update(Milliseconds timestamp) override
     {
-        if (readings.empty())
+        if (stats.count == 0)
         {
             return std::nullopt;
         }
 
-        return function->calculateForStartupInterval(readings, timestamp);
+        return function->calculate(stats, timestamp);
     }
 
     double update(Milliseconds timestamp, double reading) override
     {
-        readings.emplace_back(timestamp, reading);
-        return function->calculateForStartupInterval(readings, timestamp);
+        stats.addReading(timestamp, reading);
+
+        return function->calculate(stats, timestamp);
     }
 
   private:
     std::shared_ptr<CollectionFunction> function;
-    std::vector<ReadingItem> readings;
+    StreamingStats stats;
 };
 
 std::vector<std::unique_ptr<CollectionData>>

--- a/src/metrics/collection_function.cpp
+++ b/src/metrics/collection_function.cpp
@@ -8,91 +8,44 @@ namespace metrics
 class FunctionMinimum : public CollectionFunction
 {
   public:
-    double calculate(const std::vector<ReadingItem>& readings,
-                     Milliseconds) const override
+    double calculate(const StreamingStats& stats, Milliseconds) const override
     {
-        return std::min_element(
-                   readings.begin(), readings.end(),
-                   [](const auto& left, const auto& right) {
-                       return std::make_tuple(!std::isfinite(left.second),
-                                              left.second) <
-                              std::make_tuple(!std::isfinite(right.second),
-                                              right.second);
-                   })
-            ->second;
-    }
-
-    double calculateForStartupInterval(std::vector<ReadingItem>& readings,
-                                       Milliseconds timestamp) const override
-    {
-        readings.assign(
-            {ReadingItem(timestamp, calculate(readings, timestamp))});
-        return readings.back().second;
+        return stats.getMin();
     }
 };
 
 class FunctionMaximum : public CollectionFunction
 {
   public:
-    double calculate(const std::vector<ReadingItem>& readings,
-                     Milliseconds) const override
+    double calculate(const StreamingStats& stats, Milliseconds) const override
     {
-        return std::max_element(
-                   readings.begin(), readings.end(),
-                   [](const auto& left, const auto& right) {
-                       return std::make_tuple(std::isfinite(left.second),
-                                              left.second) <
-                              std::make_tuple(std::isfinite(right.second),
-                                              right.second);
-                   })
-            ->second;
-    }
-
-    double calculateForStartupInterval(std::vector<ReadingItem>& readings,
-                                       Milliseconds timestamp) const override
-    {
-        readings.assign(
-            {ReadingItem(timestamp, calculate(readings, timestamp))});
-        return readings.back().second;
+        return stats.getMax();
     }
 };
 
 class FunctionAverage : public CollectionFunction
 {
   public:
-    double calculate(const std::vector<ReadingItem>& readings,
+    double calculate(const StreamingStats& stats,
                      Milliseconds timestamp) const override
     {
-        auto valueSum = 0.0;
-        auto timeSum = Milliseconds{0};
-        for (auto it = readings.begin(); it != std::prev(readings.end()); ++it)
+        if (stats.count == 0)
         {
-            if (std::isfinite(it->second))
-            {
-                const auto kt = std::next(it);
-                const auto duration = kt->first - it->first;
-                valueSum += it->second * duration.count();
-                timeSum += duration;
-            }
+            return 0.0;
         }
 
-        const auto duration = timestamp - readings.back().first;
-        valueSum += readings.back().second * duration.count();
-        timeSum += duration;
+        double totalTimeWeightedSum = stats.getTimeWeightedSumMs();
+        Milliseconds totalDuration = stats.getTotalDuration();
 
-        return valueSum / std::max(timeSum.count(), uint64_t{1u});
-    }
-
-    double calculateForStartupInterval(std::vector<ReadingItem>& readings,
-                                       Milliseconds timestamp) const override
-    {
-        auto result = calculate(readings, timestamp);
-        if (std::isfinite(result))
+        if (timestamp > stats.lastTimestamp)
         {
-            readings.assign({ReadingItem(readings.front().first, result),
-                             ReadingItem(timestamp, readings.back().second)});
+            Milliseconds lastDuration = timestamp - stats.lastTimestamp;
+            totalTimeWeightedSum += stats.lastValue * lastDuration.count();
+            totalDuration += lastDuration;
         }
-        return result;
+
+        return totalTimeWeightedSum /
+               std::max(totalDuration.count(), uint64_t{1u});
     }
 };
 
@@ -101,46 +54,24 @@ class FunctionSummation : public CollectionFunction
     using Multiplier = std::chrono::duration<double>;
 
   public:
-    double calculate(const std::vector<ReadingItem>& readings,
-                     const Milliseconds timestamp) const override
+    double calculate(const StreamingStats& stats,
+                     Milliseconds timestamp) const override
     {
-        auto valueSum = 0.0;
-        for (auto it = readings.begin(); it != std::prev(readings.end()); ++it)
+        if (stats.count == 0)
         {
-            if (std::isfinite(it->second))
-            {
-                const auto kt = std::next(it);
-                const auto multiplier =
-                    calculateMultiplier(kt->first - it->first);
-                valueSum += it->second * multiplier.count();
-            }
+            return 0.0;
         }
 
-        const auto multiplier =
-            calculateMultiplier(timestamp - readings.back().first);
-        valueSum += readings.back().second * multiplier.count();
+        double totalTimeWeightedSum = stats.getTimeWeightedSumSec();
 
-        return valueSum;
-    }
-
-    double
-        calculateForStartupInterval(std::vector<ReadingItem>& readings,
-                                    const Milliseconds timestamp) const override
-    {
-        const auto result = calculate(readings, timestamp);
-        if (readings.size() > 2 && std::isfinite(result))
+        if (timestamp > stats.lastTimestamp)
         {
-            const auto multiplier =
-                calculateMultiplier(timestamp - readings.front().first).count();
-            if (multiplier > 0.)
-            {
-                const auto prevValue = result / multiplier;
-                readings.assign(
-                    {ReadingItem(readings.front().first, prevValue),
-                     ReadingItem(timestamp, readings.back().second)});
-            }
+            Milliseconds lastDuration = timestamp - stats.lastTimestamp;
+            const auto multiplier = calculateMultiplier(lastDuration);
+            totalTimeWeightedSum += stats.lastValue * multiplier.count();
         }
-        return result;
+
+        return totalTimeWeightedSum;
     }
 
   private:

--- a/src/metrics/collection_function.hpp
+++ b/src/metrics/collection_function.hpp
@@ -3,7 +3,9 @@
 #include "types/duration_types.hpp"
 #include "types/operation_type.hpp"
 
+#include <cmath>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -13,16 +15,100 @@ namespace metrics
 
 using ReadingItem = std::pair<Milliseconds, double>;
 
+struct StreamingStats
+{
+    double sum = 0.0;
+    double min = std::numeric_limits<double>::max();
+    double max = std::numeric_limits<double>::lowest();
+    uint64_t count = 0;
+    Milliseconds firstTimestamp{0};
+    Milliseconds lastTimestamp{0};
+    double lastValue = 0.0;
+    double timeWeightedSumMs = 0.0;
+    double timeWeightedSumSec = 0.0;
+    Milliseconds totalDuration{0};
+
+    void reset()
+    {
+        sum = 0.0;
+        min = std::numeric_limits<double>::max();
+        max = std::numeric_limits<double>::lowest();
+        count = 0;
+        firstTimestamp = Milliseconds{0};
+        lastTimestamp = Milliseconds{0};
+        lastValue = 0.0;
+        timeWeightedSumMs = 0.0;
+        timeWeightedSumSec = 0.0;
+        totalDuration = Milliseconds{0};
+    }
+
+    void addReading(Milliseconds timestamp, double value)
+    {
+        if (!std::isfinite(value))
+        {
+            return;
+        }
+
+        if (count > 0)
+        {
+            Milliseconds duration = timestamp - lastTimestamp;
+            // For average: value * milliseconds
+            timeWeightedSumMs += lastValue * duration.count();
+            // For sum: value * seconds
+            timeWeightedSumSec += lastValue * (duration.count() / 1000.0);
+            totalDuration += duration;
+        }
+        else
+        {
+            firstTimestamp = timestamp;
+        }
+
+        sum += value;
+        count++;
+        min = std::min(min, value);
+        max = std::max(max, value);
+        lastTimestamp = timestamp;
+        lastValue = value;
+    }
+
+    double getMin() const
+    {
+        return (count > 0) ? min : 0.0;
+    }
+
+    double getMax() const
+    {
+        return (count > 0) ? max : 0.0;
+    }
+
+    double getSum() const
+    {
+        return sum;
+    }
+
+    double getTimeWeightedSumMs() const
+    {
+        return timeWeightedSumMs;
+    }
+
+    double getTimeWeightedSumSec() const
+    {
+        return timeWeightedSumSec;
+    }
+
+    Milliseconds getTotalDuration() const
+    {
+        return totalDuration;
+    }
+};
+
 class CollectionFunction
 {
   public:
     virtual ~CollectionFunction() = default;
 
-    virtual double calculate(const std::vector<ReadingItem>& readings,
+    virtual double calculate(const StreamingStats& stats,
                              Milliseconds timestamp) const = 0;
-    virtual double
-        calculateForStartupInterval(std::vector<ReadingItem>& readings,
-                                    Milliseconds timestamp) const = 0;
 };
 
 std::shared_ptr<CollectionFunction> makeCollectionFunction(OperationType);

--- a/src/utils/conversion_trigger.hpp
+++ b/src/utils/conversion_trigger.hpp
@@ -45,8 +45,8 @@ template <typename T>
 inline constexpr bool is_variant_v = is_variant<T>::value;
 
 template <typename AlternativeT, typename VariantT>
-    requires is_variant_v<VariantT> bool
-isFirstElementOfType(const std::vector<VariantT>& collection)
+    requires is_variant_v<VariantT>
+bool isFirstElementOfType(const std::vector<VariantT>& collection)
 {
     if (collection.empty())
     {

--- a/tests/src/dbus_environment.hpp
+++ b/tests/src/dbus_environment.hpp
@@ -31,7 +31,8 @@ class DbusEnvironment : public ::testing::Environment
     static void synchronizeIoc()
     {
         while (ioc.poll() > 0)
-        {}
+        {
+        }
     }
 
     template <class Functor>

--- a/tests/src/test_metric.cpp
+++ b/tests/src/test_metric.cpp
@@ -260,7 +260,7 @@ INSTANTIATE_TEST_SUITE_P(
            defaultMinParams()
                .collectionTimeScope(CollectionTimeScope::interval)
                .collectionDuration(CollectionDuration(3ms))
-               .expectedReading(systemTimestamp + 16ms, 7.0),
+               .expectedReading(systemTimestamp + 16ms, 3.0),
            defaultMinParams()
                .collectionTimeScope(CollectionTimeScope::startup)
                .expectedReading(systemTimestamp + 16ms, 3.0)
@@ -284,7 +284,7 @@ INSTANTIATE_TEST_SUITE_P(
            defaultMaxParams()
                .collectionTimeScope(CollectionTimeScope::interval)
                .collectionDuration(CollectionDuration(5ms))
-               .expectedReading(systemTimestamp + 16ms, 7.0),
+               .expectedReading(systemTimestamp + 16ms, 14.0),
            defaultMaxParams()
                .collectionTimeScope(CollectionTimeScope::startup)
                .expectedReading(systemTimestamp + 16ms, 14.0)
@@ -306,11 +306,12 @@ INSTANTIATE_TEST_SUITE_P(
                .collectionTimeScope(CollectionTimeScope::interval)
                .collectionDuration(CollectionDuration(8ms))
                .expectedReading(systemTimestamp + 16ms,
-                                14. * 0.002 + 3. * 0.001 + 7 * 0.005),
+                                14. * 0.01 + 3. * 0.001 + 7 * 0.005),
            defaultSumParams()
                .collectionTimeScope(CollectionTimeScope::interval)
                .collectionDuration(CollectionDuration(6ms))
-               .expectedReading(systemTimestamp + 16ms, 3. * 0.001 + 7 * 0.005),
+               .expectedReading(systemTimestamp + 16ms,
+                                14. * 0.01 + 3 * 0.001 + 7 * 0.005),
            defaultSumParams()
                .collectionTimeScope(CollectionTimeScope::startup)
                .expectedReading(systemTimestamp + 16ms,
@@ -332,11 +333,12 @@ INSTANTIATE_TEST_SUITE_P(
                .collectionTimeScope(CollectionTimeScope::interval)
                .collectionDuration(CollectionDuration(8ms))
                .expectedReading(systemTimestamp + 16ms,
-                                (14. * 2 + 3. * 1 + 7 * 5) / 8.),
+                                (14. * 10 + 3. * 1 + 7 * 5) / 16.),
            defaultAvgParams()
                .collectionTimeScope(CollectionTimeScope::interval)
                .collectionDuration(CollectionDuration(6ms))
-               .expectedReading(systemTimestamp + 16ms, (3. * 1 + 7 * 5) / 6.),
+               .expectedReading(systemTimestamp + 16ms,
+                                (14. * 10 + 3. * 1 + 7 * 5) / 16.),
            defaultAvgParams()
                .collectionTimeScope(CollectionTimeScope::startup)
                .expectedReading(systemTimestamp + 16ms,

--- a/tests/src/test_report_manager.cpp
+++ b/tests/src/test_report_manager.cpp
@@ -146,7 +146,7 @@ TEST_F(TestReportManager, addReportWithOnlyDefaultParams)
     EXPECT_CALL(reportFactoryMock, convertMetricParams(_, _));
     EXPECT_CALL(reportFactoryMock,
                 make("Report"s, "Report"s, ReportingType::onRequest,
-                     std::vector<ReportAction>{}, Milliseconds{}, 256,
+                     std::vector<ReportAction>{}, Milliseconds{}, 1024,
                      ReportUpdates::overwrite, _, _,
                      std::vector<LabeledMetricParameters>{}, true, Readings{}))
         .WillOnce(Return(ByMove(std::move(reportMockPtr))));


### PR DESCRIPTION
Modified the algorithms that calculate the average, minimum, maximum and summation to use streaming/incremental calculations instead of storing all the sensor readings. All collection types (Point, Interval, Startup) now use the same streaming approach.

Tested: Sensor readings were taken over several hours to see the memory savings using the new implementation.
Memory savings were observed compared to original.

Using the top command, memory usage for telemetry was monitored and the memory growth was observed with the original implementation

Original implementation shows memory increasing
`
~# top | grep telemetry
  592     1 root     S     6988   1%   0   0% /usr/bin/telemetry

~# top | grep telemetry
  592     1 root     S     9076   1%   0   0% /usr/bin/telemetry
`

New implementation
`
~# top | grep telemetry
  599     1 root     S     6940   1%   1   0% /usr/bin/telemetry

~# top | grep telemetry
  599     1 root     S     6940   1%   1   0% /usr/bin/telemetry
`

This implementation uses a fixed interval, as readings are not stored in memory. Some testcases were modified to support this.

Change-Id: Ib4c1b3975b3458bcecd35bd8fc49fe8399a5d324